### PR TITLE
Prepare version 2.0.0 of react-native-zello-sdk

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,13 +5,13 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version-file: .nvmrc
 
     - name: Cache dependencies
       id: yarn-cache
-      uses: actions/cache@v3
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       with:
         path: |
           **/node_modules

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,13 @@
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+ignore_actions:
+#   - name: actions/.*
+#     ref: main
+  - name: zelloptt/.*
+    ref: v.*
+  - name: zelloptt/zello-devops/.github/workflows/lint-pr-title.yml
+    ref: master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -56,13 +56,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/android
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for Android
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install JDK
         if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache Gradle
         if: env.turbo_cache_hit != 1
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: |
             ~/.gradle/wrapper
@@ -112,13 +112,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for iOS
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
@@ -136,7 +136,7 @@ jobs:
       - name: Cache cocoapods
         if: env.turbo_cache_hit != 1
         id: cocoapods-cache
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: |
             **/ios/Pods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 2.0.0
+
+### BREAKING CHANGES
+
+* Dropped support for iOS 14 — minimum supported version is now iOS 15.
+* Updating to SDK 2.0.0 or higher will be **required** to continue communication with Zello servers starting October 2025.
+
 # 1.0.3
 
 ### Bug Fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -102,7 +102,7 @@ repositories {
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
-def zelloSdkVersion = "1.0.1"
+def zelloSdkVersion = "1.0.3"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -79,6 +79,6 @@ target 'NotificationServiceExtension' do
   use_frameworks!
 
   # IMPORTANT: Make sure this is the same version as the podspec
-  pod "ZelloSDK", "~> 1.0.0"
+  pod "ZelloSDK", "~> 2.0.0"
 
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -963,7 +963,7 @@ PODS:
     - React-debug
   - react-native-safe-area-context (4.10.8):
     - React-Core
-  - react-native-zello-sdk (1.0.2):
+  - react-native-zello-sdk (2.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -984,7 +984,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-    - ZelloSDK (~> 1.0.0)
+    - ZelloSDK (~> 2.0.0)
   - React-nativeconfig (0.74.5)
   - React-NativeModulesApple (0.74.5):
     - glog
@@ -1263,20 +1263,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - SDWebImage (5.20.0):
-    - SDWebImage/Core (= 5.20.0)
-  - SDWebImage/Core (5.20.0)
-  - SnowplowTracker (6.0.8)
+  - SDWebImage (5.21.1):
+    - SDWebImage/Core (= 5.21.1)
+  - SDWebImage/Core (5.21.1)
+  - SnowplowTracker (6.2.2)
   - SocketRocket (0.7.0)
   - Yoga (0.0.0)
   - zello-opus-ios (1.0.2)
-  - ZelloSDK (1.0.0):
+  - ZelloSDK (2.0.0):
     - CocoaAsyncSocket (~> 7.6)
-    - CocoaLumberjack/Swift (~> 3.7)
+    - CocoaLumberjack/Swift (~> 3.8)
     - OpenSSL-Universal (~> 1.1)
-    - PhoneNumberKit/PhoneNumberKitCore (~> 3.6)
-    - PromisesSwift (~> 2.1)
-    - SDWebImage (~> 5.13)
+    - PhoneNumberKit/PhoneNumberKitCore (~> 3.7)
+    - PromisesSwift (~> 2.4)
+    - SDWebImage (~> 5.19)
     - SnowplowTracker (~> 6.0)
     - zello-opus-ios (~> 1.0)
 
@@ -1344,7 +1344,7 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
-  - ZelloSDK (~> 1.0.0)
+  - ZelloSDK (~> 2.0.0)
 
 SPEC REPOS:
   trunk:
@@ -1506,67 +1506,67 @@ SPEC CHECKSUMS:
   PhoneNumberKit: ec00ab8cef5342c1dc49fadb99d23fa7e66cf0ef
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 5dc73daec3476616d19e8a53f0156176f7b55461
   RCTDeprecation: 3afceddffa65aee666dafd6f0116f1d975db1584
   RCTRequired: ec1239bc9d8bf63e10fb92bd8b26171a9258e0c1
   RCTTypeSafety: f5ecbc86c5c5fa163c05acb7a1c5012e15b5f994
   React: fc9fa7258eff606f44d58c5b233a82dc9cf09018
   React-callinvoker: e3fab14d69607fb7e8e3a57e5a415aed863d3599
-  React-Codegen: bd1a15f54af401efee5f439aa6fd420b10550125
-  React-Core: 3a5fd9e781cecf87803e5b091496a606a3df774a
-  React-CoreModules: cbf4707dafab8f9f826ac0c63a07d0bf5d01e256
-  React-cxxreact: 7b188556271e3c7fdf22a04819f6a6225045b9dd
+  React-Codegen: 182c34dab69df9386bf8e7abb46f7d47d12cd79d
+  React-Core: c3f589f104983dec3c3eeec5e70d61aa811bc236
+  React-CoreModules: 864932ddae3ead5af5bfb05f9bbc2cedcb958b39
+  React-cxxreact: bd9146108c44e6dbb99bba4568ce7af0304a2419
   React-debug: 2d6f912c0c4c91a9fde617d8425088af7315c10b
-  React-Fabric: 47ff62e0c7f017606585327f6016190625295c5e
-  React-FabricImage: 823627aa521b4ecc896334f0dbf2bc8376edbf1e
+  React-Fabric: bdc743e99c11fdf1c2523bdd500827431e550fa8
+  React-FabricImage: 0d72f410fb5d6106e9f6fc6c60851ea5a39e7e88
   React-featureflags: 2a4555681de0d4b683d98d7e9fd7bdf9e9ce1aa2
-  React-graphics: edbd2a6c018b2e2d541ab8cb886cc31babf14646
-  React-hermes: a7054fbcbda3957e3c5eaad06ef9bf79998d535a
-  React-ImageManager: 314824c4bb6f152699724dc9eb3ce544b87048bd
-  React-jserrorhandler: fffe10523886a352161ef492af2063651721c8ee
-  React-jsi: f3ce1dd2e950b6ad12b65ea3ef89168f1b94c584
-  React-jsiexecutor: b4df3a27973d82f9abf3c4bd0f88e042cda25f16
-  React-jsinspector: 2ea90b8e53970a1fea1449fb8e6419e21ca79867
-  React-jsitracing: c83efb63c8e9e1dff72a3c56e88ae1c530a87795
-  React-logger: 257858bd55f3a4e1bc0cf07ddc8fb9faba6f8c7c
-  React-Mapbuffer: dce508662b995ffefd29e278a16b78217039d43d
-  react-native-safe-area-context: b7daa1a8df36095a032dff095a1ea8963cb48371
-  react-native-zello-sdk: bf0f0088c1cf5059e059c9f10c6d526283761ad1
+  React-graphics: 7b0f29341f82b5aac0f956a8a7f3c02b6ddfceab
+  React-hermes: 177b1efdf3b8f10f4ca12b624b83fb4d4ccb2884
+  React-ImageManager: c649561999bf66aff58e2d89b470a0d6d3a32122
+  React-jserrorhandler: c072daf0ab61334efbfaa966afeb0e3b2db520c8
+  React-jsi: 0abe1b0881b67caf8d8df6a57778dd0d3bb9d9a5
+  React-jsiexecutor: f6ca8c04f19f6a3acaa9610f7fb728f39d6e3248
+  React-jsinspector: 782332199759466a60b1a3b698902351c7faba9f
+  React-jsitracing: d73503c33d42ae2c0732945338cff966e41cc51e
+  React-logger: 780b9ee9cec7d44eabc4093de90107c379078cb6
+  React-Mapbuffer: 32481ad50f09c781bdb408b302757e0c9285d6db
+  react-native-safe-area-context: b72c4611af2e86d80a59ac76279043d8f75f454c
+  react-native-zello-sdk: 0ebf43948f8f309c1adffd677f67b4a7343b1722
   React-nativeconfig: f326487bc61eba3f0e328da6efb2711533dcac46
-  React-NativeModulesApple: d89733f5baed8b9249ca5a8e497d63c550097312
+  React-NativeModulesApple: ab18cfc286c91012535b94553222f455eedf2c53
   React-perflogger: ed4e0c65781521e0424f2e5e40b40cc7879d737e
   React-RCTActionSheet: 49d53ff03bb5688ca4606c55859053a0cd129ea5
-  React-RCTAnimation: 07b4923885c52c397c4ec103924bf6e53b42c73e
-  React-RCTAppDelegate: 316e295076734baf9bdf1bfac7d92ab647aed930
-  React-RCTBlob: 85c57b0d5e667ff8a472163ba3af0628171a64bb
-  React-RCTFabric: 62695e345da7c451b05a131f0c6ba80367dbd5c3
-  React-RCTImage: b965c85bec820e2a9c154b1fb00a2ecdd59a9c92
-  React-RCTLinking: 75f04a5f27c26c4e73a39c50df470820d219df79
-  React-RCTNetwork: c1a9143f4d5778efc92da40d83969d03912ccc24
-  React-RCTSettings: c6800f91c0ecd48868cd5db754b0b0a7f5ffe039
-  React-RCTText: b923e24f9b7250bc4f7ab154c4168ad9f8d8fc9d
-  React-RCTVibration: 08c4f0c917c435b3619386c25a94ee5d64c250f0
-  React-rendererdebug: fac75dc155e1202cfc187485a6e4f6e842fcc5c7
+  React-RCTAnimation: 3075449f26cb98a52bcbf51cccd0c7954e2a71db
+  React-RCTAppDelegate: 9a419c4dda9dd039ad851411546dd297b930c454
+  React-RCTBlob: e81ab773a8fc1e9dceed953e889f936a7b7b3aa6
+  React-RCTFabric: 0b4163b65e0be4a7521e59dfe12a52159301c88b
+  React-RCTImage: d570531201c6dce7b5b63878fa8ecec0cc311c4c
+  React-RCTLinking: af888972b925d2811633d47853c479e88c35eb4d
+  React-RCTNetwork: 5728a06ff595003eca628f43f112a804f4a9a970
+  React-RCTSettings: ba3665b0569714a8aaceee5c7d23b943e333fa55
+  React-RCTText: b733fa984f0336b072e47512898ba91214f66ddb
+  React-RCTVibration: 0cbcbbd8781b6f6123671bae9ee5dd20d621af6c
+  React-rendererdebug: d005c4641b9bae31c2bcccf0579d6a35105f5c6f
   React-rncore: 12dc32f08f195e573e9d969a348b976a3d057bbc
-  React-RuntimeApple: 5c7591dd19de1c7fefe8e61cf934d8f8f9fc0409
-  React-RuntimeCore: ec3c8be706ca2e4607eb8c675d32512352501f9e
+  React-RuntimeApple: b9183d85d31f20b358738231cfb2fb5ee795980f
+  React-RuntimeCore: c548c0b9134ca7149f0979deabf71eaa1c2fde90
   React-runtimeexecutor: 0e688aefc14c6bc8601f4968d8d01c3fb6446844
-  React-RuntimeHermes: df243bd7c8d4ba3bd237ce6ded22031e02d37908
-  React-runtimescheduler: db7189185a2e5912b0d17194302e501f801a381e
-  React-utils: 3f1fcffc14893afb9a7e5b7c736353873cc5fc95
-  ReactCommon: f79ae672224dc1e6c2d932062176883c98eebd57
-  RNCPicker: b7873ba797dc586bfaf3307d737cbdc620a9ff3e
-  RNFBApp: 614f1621b49db54ebd258df8c45427370d8d84a2
-  RNPermissions: f6e13cafabd1db7bfbe47a8d91dbbc5356d32b3e
-  RNScreens: cfe03c0356f5d19e1f04e45b7e2ff6edd92fe6e1
-  RNVectorIcons: 7ac7aaa83f8f3d4c7c0f7daea5a431e91a29b0cd
-  SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  SnowplowTracker: c7dcb63a584038ac3459bc803bfedec98cf87de9
+  React-RuntimeHermes: caf82d8f3cb32eeb54bd9b4079aa58a11c77ba3a
+  React-runtimescheduler: 914607b0f1a58e1a8366c13f8d2efb49c17d57d1
+  React-utils: 3c4b8677afc614f15357ad66fcc3e61bc21a42db
+  ReactCommon: cfb89afbdafafbf049c719db9cb61ac4d38af434
+  RNCPicker: ba7ceb25a6e7c1d98aec9fa5a0d842934c7b316e
+  RNFBApp: 5ee7b01b1821f27f5749dda020fa09fa6c6975cd
+  RNPermissions: eac3491e99d20b3a794c5bca1905f872a35f4b22
+  RNScreens: 704c2759dc669ca2c29b457acb9cd3497575de8b
+  RNVectorIcons: 551fe889ea7d3c5d0adf2d9e85106ca24b8f60c5
+  SDWebImage: f29024626962457f3470184232766516dee8dfea
+  SnowplowTracker: bd92a5bd67705ec2a7dc630576c22e13cf6c8b45
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
   zello-opus-ios: 2c22467bba9a102886f1d84fe035b469a3b27f08
-  ZelloSDK: 38bd1581f93072d521ee708064577fe009349f02
+  ZelloSDK: 1b0190ba6a134dbeae1d07f276cfb40992c205f6
 
-PODFILE CHECKSUM: 2420b2b2d35e8155b51cf07f8b3d872d94eba375
+PODFILE CHECKSUM: 4337c413a64afa1fecdea9c178e59e510509f60b
 
 COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zelloptt/react-native-zello-sdk",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zelloptt/react-native-zello-sdk",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zelloptt/react-native-zello-sdk",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Zello SDK for React Native",
   "source": "./src/index",
   "main": "./lib/commonjs/index.js",

--- a/react-native-zello-sdk.podspec
+++ b/react-native-zello-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'ZelloSDK', '~> 1.0.0'
+  s.dependency 'ZelloSDK', '~> 2.0.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,7 +2076,7 @@
   version "1.2.0"
 
 "@zelloptt/react-native-zello-sdk@file:..":
-  version "1.0.2"
+  version "2.0.0"
   resolved "file:"
 
 abort-controller@^3.0.0:
@@ -6030,7 +6030,7 @@ react-native-vector-icons@*, react-native-vector-icons@10.1.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-"react-native-zello-sdk-example@file:/Users/nadehz/Desktop/react-native-zello-sdk/example":
+"react-native-zello-sdk-example@file:/Users/developer/react-native-zello-sdk-v3/example":
   version "0.0.1"
   resolved "file:example"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6030,7 +6030,7 @@ react-native-vector-icons@*, react-native-vector-icons@10.1.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-"react-native-zello-sdk-example@file:/Users/developer/react-native-zello-sdk-v3/example":
+"react-native-zello-sdk-example@file:/Users/developer/react-native-zello-sdk/example":
   version "0.0.1"
   resolved "file:example"
   dependencies:


### PR DESCRIPTION
This pull request finalizes the changes for the 2.0.0 major release of the @zelloptt/react-native-zello-sdk package.

Bumped package version from 1.0.2 to 2.0.0 across:
	•	package.json
	•	package-lock.json
	•	Podfile, Podfile.lock, and .podspec
	•	CHANGELOG.md updated accordingly

⚠️ Breaking Changes
	•	Dropped support for iOS 14. The minimum supported iOS version is now 15.
	•	Important Notice: Starting October 2025, all apps must upgrade to SDK version 2.0.0 or higher to continue connecting with Zello servers.

⚙️ Dependency Updates
	•	Updated dependency on ZelloSDK from ~> 1.0.0 to ~> 2.0.0
	•	Updated Android zelloSdkVersion to 1.0.3