### PR TITLE
fix(example): lock android theme to light to match ios

### DIFF
--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>


### PR DESCRIPTION
## Summary

The example app does not render correctly on Android in dark mode: hardcoded white modal dialogs (StatusDialog, ConnectModal, IncomingTextDialog, OutgoingTextDialog, HistoryDialog, etc.) render with the system white text color, making content invisible.

iOS was already pinned to light via `UIUserInterfaceStyle = Light` in `Info.plist`, but Android used `Theme.AppCompat.DayNight.NoActionBar`, which follows the system theme. This change matches iOS by locking Android to the Light theme, so both platforms render consistently with the existing hardcoded light styles.

This is the minimum changeset to fix rendering; proper dark-mode support would require introducing a theme-aware color system across all dialogs and screens.

## Changes

- `example/android/app/src/main/res/values/styles.xml`: `Theme.AppCompat.DayNight.NoActionBar` -> `Theme.AppCompat.Light.NoActionBar`

## Test plan

- [ ] Build and run the example app on an Android device/emulator with system dark mode enabled
- [ ] Verify FlatList rows and all modal dialogs render with readable text
- [ ] Build and run on iOS to confirm no regression
